### PR TITLE
Fix: check if retry options are set

### DIFF
--- a/src/OneflowSDK.php
+++ b/src/OneflowSDK.php
@@ -56,9 +56,9 @@ class OneflowSDK {
 		$this->apiName = "connect";
 		$this->version = "0.1";
 		$this->authHeader = "x-oneflow-authorization";
-		$this->retries = $options->retries ?: 3;
-		$this->retryCondition = $options->retryCondition ?: "OneflowSDK::isRetryableError";
-		$this->retryDelay = $options->retryDelay ?: "OneflowSDK::exponentialDelay";
+		$this->retries = isset($options->retries) ? $options->retries : 3;
+		$this->retryCondition = isset($options->retryCondition) ? $options->retryCondition : "OneflowSDK::isRetryableError";
+		$this->retryDelay = isset($options->retryDelay) ? $options->retryDelay : "OneflowSDK::exponentialDelay";	
 	}
 
 	//ACCOUNTS

--- a/src/OneflowSDK.php
+++ b/src/OneflowSDK.php
@@ -58,7 +58,7 @@ class OneflowSDK {
 		$this->authHeader = "x-oneflow-authorization";
 		$this->retries = isset($options->retries) ? $options->retries : 3;
 		$this->retryCondition = isset($options->retryCondition) ? $options->retryCondition : "OneflowSDK::isRetryableError";
-		$this->retryDelay = isset($options->retryDelay) ? $options->retryDelay : "OneflowSDK::exponentialDelay";	
+		$this->retryDelay = isset($options->retryDelay) ? $options->retryDelay : "OneflowSDK::exponentialDelay";
 	}
 
 	//ACCOUNTS


### PR DESCRIPTION
Fix warning: Trying to get property 'retries' of non-object #40

Remove warning in strict mode by checking if retry options are set